### PR TITLE
Automatic generation for 2018 GSoC archive

### DIFF
--- a/gsoc/2018/index.md
+++ b/gsoc/2018/index.md
@@ -16,78 +16,21 @@ The HSF GSoC 2018 Administrators were Sergei Gleyzer <a href="mailto:sergei@cern
 *N.B.* This page **archives** the proposals from the 2018 Google Summer of Code. For information on the latest
 GSoC please see [here](/activities/gsoc.html).
 
+## Projects in 2018
 
-## Projects
+{% assign current_year = "2018" %}
+{% include gsoc_project_list.ext year=current_year %}
 
-{:.table .table-hover  .table-striped}
-| ![ACTS](/images/ACTSlogo.gif){:width="100px"} | [ACTS](http://cern.ch/acts) is a free and open-source software project for track reconstruction in high-energy physics experiments. [List of proposals](/gsoc/projects/{{ page.year }}/project_ACTS.html)|
-| ![ATLAS](/images/ATLAS-Logo-Ref-RGB.png){:width="100px"} | [ATLAS](https://atlas.web.cern.ch/Atlas/Collaboration/) is a high-energy physics experiment at the LHC. [List of proposals](/gsoc/projects/{{ page.year }}/project_ATLAS.html)|
-| ![AllpixSquared](/images/AllpixSquared.png){:width="100px"} | [Allpix Squared](https://cern.ch/allpix-squared) is a free and open-source simulation framework for silicon tracker and vertex detectors written in modern C++. [List of proposals](/gsoc/projects/{{ page.year }}/project_AllpixSquared.html)|
-| ![CERNBox](/images/CERNBox-Logo.png){:width="100px"} | [CERNBox](http://cernbox.web.cern.ch) is a cloud synchronisation service for end-users. [List of proposals](/gsoc/projects/{{ page.year }}/project_CERNBox.html)|
-| ![CMS](/images/CMS-Color.gif){:width="100px"} | [CMS](http://cms.cern/) (Compact Muon Solenoid) is a high-energy physics experiment at the LHC. [List of proposals](/gsoc/projects/{{ page.year }}/project_CMS.html)|
-| ![CernVM-FS](/images/cernvmfs-logo.png){:width="100px"} | The CernVM-File System (CernVM-FS) is a global, read-only POSIX file system that provides the universal namespace /cvmfs. [List of proposals](/gsoc/projects/{{ page.year }}/project_CernVM-FS.html)|
-| ![DD4hep](/images/DD4hep_logo_small.png){:width="100px"} | [DD4hep](http://dd4hep.cern.ch) is a framework for the complete description of detector models based on a single source of information. [List of proposals](/gsoc/projects/{{ page.year }}/project_DD4hep.html)|
-| ![DIANA-HEP](/images/DIANA-HEP-Logo.png){:width="100px"} | The primary goal of DIANA/HEP is to develop state-of-the-art software tools for experiments which acquire, reduce, and analyze petabytes of data. [List of proposals](/gsoc/projects/{{ page.year }}/project_DIANA-HEP.html)|
-| ![FALCON](/images/falcon_logo.png){:width="100px"} | Falcon is an ultra-fast non-parametric detector simulation package that automatically abstracts detector response, usually done by hand in fast-simulators used by particle physics experiments. [List of proposals](/gsoc/projects/{{ page.year }}/project_FALCON.html)|
-| ![Ganga](/images/ganga_logo_150dpi.png){:width="100px"} | [Ganga](https://ganga.web.cern.ch) is a computational task-management tool, which allows for the specification, submission, bookkeeping and post-processing of computational tasks on a wide set of distributed resources. [List of proposals](/gsoc/projects/{{ page.year }}/project_Ganga.html)|
-| ![Geant4](/images/geanttiny.gif){:width="100px"} | Geant (for GEometry ANd Tracking) is a platform for "the simulation of the passage of particles through matter," using Monte Carlo methods. [List of proposals]({{site.baseurl}}/gsoc/projects/{{ page.year }}/project_Geant4.html)|
-| ![GeantV](/images/geantv_logo.png){:width="100px"} | The GeantV project aims at developing a high performance detector simulation system integrating fastand fullsimulation that  can  be  ported  on  different  computing  architectures,  including CPU accelerators. [List of proposals](/gsoc/projects/{{ page.year }}/project_GeantV.html)|
-| ![GoHEP](/images/go-hep-logo.png){:width="100px"} | The GoHEP project aims at developing robust and concurrency friendly libraries for HEP, astrophysics and cosmology. [List of proposals](/gsoc/projects/{{ page.year }}/project_GoHEP.html)|
-| **GoInterpreter** | The `GoInterpreter` project aims to provide an interpreter for the `Go` language. [List of proposals](/gsoc/projects/{{ page.year }}/project_GoInterpreter.html)|
-| ![HAhRD](/images/HAhRD-logo.jpg){:width="100px"} | The [HAhRD](https://github.com/grasseau/HAhRD/wiki) (HPC Algorithms for high Resolution Detectors) aims to investigate new methods based on statistics, Machine Learning, and/or image processing for high resolution detectors of sub-detectors in HEP. [List of proposals](/gsoc/projects/{{ page.year }}/project_HAhRD.html)|
-| ![HSF](/images/kubernetes.png){:width="100px"} | [Kubernetes](https://kubernetes.io/) is an open-source system for automating deployment, scaling, and management of containerized applications. [List of proposals](/gsoc/projects/{{ page.year }}/project_Kubernetes.html)|
-| ![LHCb](/images/lhcb_logo.png){:width="100px"} | [LHCb](http://lhcb.web.cern.ch/lhcb/) is a high-energy physics experiment at the LHC. [List of proposals](/gsoc/projects/{{ page.year }}/project_LHCb.html)|
-| ![NEXT](/images/NEXT-Logo.png){:width="100px"} | [NEXT](http://next.ific.uv.es/next/) is a Xenon gas neutrino-less double beta decay experiment. [List of proposals](/gsoc/projects/{{ page.year }}/project_NEXT.html)|
-| ![ROOT](/images/rootlogo.png){:width="100px"} | A modular scientific software framework. It provides all the functionalities needed to deal with big data processing, statistical analysis, visualisation and storage. It is mainly written in C++ but integrated with other languages such as Python and R. [List of proposals](/gsoc/projects/{{ page.year }}/project_ROOT.html)|
-| ![SixTrack](/images/sixtrack_logo.png){:width="100px"} | [SixTrack](http://cern.ch/sixtrack) is a software for simulating and analysing the trajectory of high energy particles in accelerators. It has been used in the design and optimization of the LHC and is now being used to design the High-Luminosity LHC (HL-LHC) upgrade that will be installed in the next decade. [List of proposals](/gsoc/projects/{{ page.year }}/project_SixTrack.html) |
-| ![Spark3D](/images/spark3d_logo.jpg){:width="100px"} | [Spark3D](https://astrolabsoftware.github.io/spark3D/) can be viewed as an extension of the Apache Spark framework, and more specifically the Spark SQL module, focusing on the manipulation of three-dimensional data sets. [List of proposals](/gsoc/projects/{{ page.year }}/project_Spark3D.html)|
-| ![TMVA](/images/tmva_logo.gif){:width="100px"} | TMVA is a ROOT-integrated toolkit for multivariate classification and regression analysis. TMVA performs the training, testing and performance evaluation of a large variety of multivariate methods. [List of proposals]({{site.baseurl}}/gsoc/projects/{{ page.year }}/project_TMVA.html)|
-| ![WLCG](/images/WLCG_logo.png){:width="100px"} | [Worldwide LHC Computing Grid](http://wlcg.web.cern.ch)(WLCG) project is a global collaboration of more than 170 computing centres in 42 countries, linking up national and international grid infrastructures. [List of proposals](/gsoc/projects/{{ page.year }}/project_WLCG.html)|
-| ![XROOTD](/images/XROOTD-Logo.png){:width="100px"} | [XROOTD](http://xrootd.org/) project aims at giving high performance, scalable fault tolerant access to data repositories of many kinds. [List of proposals](/gsoc/projects/{{ page.year }}/project_XROOTD.html)|
+## Participating Organizations in 2018
 
+{% include gsoc_organization_list.ext year=current_year %}
 
+## Summary
 
+[Full list of Proposal Ideas](/gsoc/2018/summary.html)
 
-## Participating Organizations
+[Full list of Mentors](/gsoc/2018/mentors.html)
 
-{:.table .table-hover  .table-striped}
-| ![AARNET](/images/aarnet-logo.png){:width="100px"} | AARNet provides Internet services to the Australian education and research  communities and their research partners. [List of proposals](/gsoc/organisations/{{ page.year }}/aarnet.html)|
-| ![ANL](/images/anl-logo.gif){:width="100px"} | Argonne National Lab (ANL) is a multidisciplinary science and engineering research center. [List of proposals](/gsoc/organisations/{{ page.year }}/anl.html)|
-| ![CERN](/images/CERN-logo.jpg){:width="100px"} | At CERN, the European Organization for Nuclear Research, physicists and engineers are probing the fundamental structure of the universe. They use the world's largest and most complex scientific instruments to study the basic constituents of matter – the fundamental particles. [List of proposals]({{site.baseurl}}/gsoc/organizations/{{ page.year }}/cern.html)|
-| ![University of Cincinnati ](/images/Uc-seal.png){:width="100px"} | University of Cincinnati [List of proposals](/gsoc/organizations/{{ page.year }}/cincinnati.html)|
-| ![EDINBURGH](/images/logo_uoe.png){:width="100px"} | The University of Edinburgh is a charitable body, registered in Scotland. [List of proposals](/gsoc/organisations/{{ page.year }}/edinburgh.html)|
-| ![EPFL](/images/Logo_EPFL.png){:width="100px"} | The École polytechnique fédérale de Lausanne (EPFL) is a research institute and university in Lausanne, Switzerland, that specializes in natural sciences and engineering. [List of proposals](/gsoc/organisations/{{ page.year }}/epfl.html)|
-| ![ETH](/images/Eth-zurich_logo.png){:width="100px"} | ETH Zurich (Swiss Federal Institute of Technology in Zurich; German: Eidgenössische Technische Hochschule Zürich) is a science, technology, engineering and mathematics university in the city of Zürich, Switzerland. [List of proposals](/gsoc/organisations/{{ page.year }}/eth.html)|
-| ![University of Florida](/images/ufl_logo.jpg){:width="100px"} | University of Florida is a public institution that was founded in 1853. [List of proposals](/gsoc/organizations/{{ page.year }}/uflorida.html)|
-| ![Florida State University](/images/fsu_logo.jpg){:width="100px"} | Florida State University is a public institution that was founded in 1851. [List of proposals](/gsoc/organizations/{{ page.year }}/fsu.html)|
-| ![ICELANDUNIVERSITY](/images/iceland.jpeg){:width="100px"} | The University of Iceland is an international research university and a leading research institution in Iceland. [List of proposals](/gsoc/organisations/{{ page.year }}/icelanduniversity.html)|
-| ![IMPERIALCOLLEGE](/images/Imperial-College-London2.png){:width="100px"} | [Imperial College London](https://www.imperial.ac.uk/) is a world top ten university with an international reputation for excellence in teaching and research. [List of proposals](/gsoc/organisations/{{ page.year }}/imperialcollege.html)|
-| ![Karlsruhe Institute of Technology](/images/kit_logo.png){:width="100px"} | The Karlsruhe Institute of Technology is a public research university and one of the largest research and education institutions in Germany. [List of proposals](/gsoc/organizations/{{ page.year }}/kit.html)|
-| ![LAL](/images/logo_LAL.jpg){:width="100px"} | [LAL](http://www.lal.in2p3.fr) is a French research laboratory belonging to CNRS/IN2P3 and located at Université Paris Sud. The main topics of the research done at LAL are high energy physics, cosmology and accelerators. [List of proposals](/gsoc/organizations/{{ page.year }}/lal.html)|
-| ![LBNL](/images/LBL_Logo.jpg){:width="100px"} | Lawrence Berkeley National Lab (LBNL) is a member of the national laboratory system supported by the U.S. Department of Energy through its Office of Science. [List of proposals](/gsoc/organisations/{{ page.year }}/lbnl.html)|
-| ![LLR](/images/LLR-logo.jpg){:width="100px"} | The Leprince-Ringuet Laboratory (LLR) is located at Ecole Polytechnique, near Paris. The main research activities of LLR concern particle physics and very high energy gamma astronomy. [List of proposals](/gsoc/organisations/{{ page.year }}/llr.html)|
-| ![LPC](/images/lpc-logo.png){:width="100px"} | Founded in 1958, Laboratoire de Physique de Clermont is a government-funded mixed research unit (CNRS/IN2P3 and University Clermont Auvergne), in Auvergne, France. [List of proposals](/gsoc/organizations/{{ page.year }}/lpc-clermont.html)|
-| ![LUT](/images/lut_logo.jpg){:width="100px"} | Lulea University of Technology (Swedish: Luleå tekniska universitet) of Sweden is Scandinavia's northernmost university of technology. [List of proposals](/gsoc/organisations/{{ page.year }}/lut.html)|
-| ![MIPT](/images/MIPT_logo.jpg){:width="100px"} | The Moscow Institute of Physics and Technology is a Russian university, originally established in the Soviet Union. It prepares specialists in theoretical and applied physics, applied mathematics, and related disciplines. [List of proposals](/gsoc/organisations/{{ page.year }}/mipt.html)|
-| ![NIKHEF](/images/logo_nikhef.svg){:width="100px"} | The National Institute for Subatomic Physics Nikhef is to studies the interactions and structure of all elementary particles and fields at the smallest distance scale and the highest attainable energy. [List of proposals](/gsoc/organisations/{{ page.year }}/nikhef.html)|
-| ![OPROJECT](/images/oproject-logo.png){:width="100px"} | [OProject](http://oproject.org) Open source organization, specialized in development  of advaced scientfic software with ROOT, focused  mathematical/statistical tools, machine learning and high performance computing. [List of proposals](/gsoc/organisations/{{ page.year }}/oproject.html)|
-| ![OWNCLOUD](/images/owncloud-logo.png){:width="100px"} | ownCloud, Inc. develops a universal file access platform that is hosted in user’s data center and servers using their storage. [List of proposals](/gsoc/organisations/{{ page.year }}/owncloud.html)|
-| ![Princeton University](/images/princeton-logo.png){:width="100px"} | Princeton University is a private Ivy League research university in Princeton, New Jersey. [List of proposals](/gsoc/organizations/{{ page.year }}/princeton.html)|
-| ![RAL](/images/logo_RAL.jpg){:width="100px"} | STFC Rutherford Appleton Laboratory in Oxfordshire, United Kingdom is home to national facilities including the Diamond synchroton and ISIS neutron spallation source. The Particle Physics Department contributes to experiments including ATLAS, CMS and T2K. [List of proposals](/gsoc/organizations/{{ page.year }}/ral.html)|
-| ![Universidad de Antioquia](/images/udea_logo.png){:width="100px"} | Established in 1803, Universidad de Antioquia is a government-run public university based in Medellín, Colombia. [List of proposals](/gsoc/organizations/{{ page.year }}/udea.html)|
-| ![Universitat Jaume I](/images/uji_logo.jpg){:width="100px"} |The Universitat Jaume I is a public university in Castelló de la Plana, Spain. [List of proposals](/gsoc/organizations/{{ page.year }}/uji.html)|
-| ![UNL](/images/unl.png){:width="100px"} | The University of Nebraska–Lincoln, often referred to as Nebraska, UNL or NU, is a public research university in the city of Lincoln, in the state of Nebraska in the Midwestern United States. [List of proposals](/gsoc/organisations/{{ page.year }}/unl.html)|
-| ![UOLDENBURG](/images/Uni_oldenburg_logo.png){:width="100px"} | The Carl von Ossietzky University of Oldenburg (German: Carl von Ossietzky Universität Oldenburg) is a university located in Oldenburg, Germany. [List of proposals](/gsoc/organisations/{{ page.year }}/uoldenburg.html)|
-| ![University of Oslo](/images/UOslo.png){:width="100px"} | [UiO](http://www.uio.no/english/) is Norway's oldest institution for research and higher education. [List of proposals](/gsoc/organizations/{{ page.year }}/uoslo.html)|
-| ![UTA](/images/UTA-logo.jpeg){:width="100px"} | The University of Texas at Arlington (UTA or UT Arlington) is a public research university located in Arlington, Texas. [List of proposals](/gsoc/organisations/{{ page.year }}/uta.html)|
-| ![UZH](/images/UZH-zurich_logo.jpg){:width="100px"} | UZH (Zürich University; German: Universität Zürich): Universität Zürich is a University made up of seven faculties covering some 100 different subject areas in the city of Zürich, Switzerland. [List of proposals](/gsoc/organisations/{{ page.year }}/uzh.html)|
+---
 
-
-
-[Full list of Proposal Ideas](/gsoc/{{page.year}}/summary.html)
-
-[Full list of Mentors](/gsoc/{{page.year}}/mentors.html)
-
-## Contact information (for students)
-Although GSoC 2018 has finished, please do not hesitate to contact us if you are
-interested in the latest GSoC program using the HSF GSoC mailing list: [hep-software-foundation-google-summer-of-code@googlegroups.com](mailto:hep-software-foundation-google-summer-of-code@googlegroups.com).
+*HSF GSoC Administrators*: [Sergei Gleyzer](mailto:sergei@cern.ch), [Enric Tejedor Saavedra](mailto:etejedor@cern.ch) and [Antoine Perus](mailto:perus@lal.in2p3.fr).

--- a/gsoc/2018/index.md
+++ b/gsoc/2018/index.md
@@ -33,4 +33,8 @@ GSoC please see [here](/activities/gsoc.html).
 
 ---
 
-*HSF GSoC Administrators*: [Sergei Gleyzer](mailto:sergei@cern.ch), [Enric Tejedor Saavedra](mailto:etejedor@cern.ch) and [Antoine Perus](mailto:perus@lal.in2p3.fr).
+## Contact information (for students)
+*HSF GSoC 2018 Administrators*: [Sergei Gleyzer](mailto:sergei@cern.ch), [Enric Tejedor Saavedra](mailto:etejedor@cern.ch) and [Antoine Perus](mailto:perus@lal.in2p3.fr).
+
+Although GSoC 2018 has finished, please do not hesitate to contact us if you are
+interested in the latest GSoC program using the HSF GSoC mailing list: [hep-software-foundation-google-summer-of-code@googlegroups.com](mailto:hep-software-foundation-google-summer-of-code@googlegroups.com).


### PR DESCRIPTION
Some of the current failures in travis are due to minor typos on image names and not generated pages, this aims to solve it.